### PR TITLE
Add VNC desktop support to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,28 @@
 FROM mcr.microsoft.com/playwright:v1.47.2-jammy
+
 WORKDIR /app
+
+# Install VNC server, noVNC and a lightweight window manager
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        fluxbox \
+        x11vnc \
+        novnc \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY package*.json ./
 RUN npm ci
 COPY . .
 RUN npx playwright install --with-deps
-ENV PORT=3000
-EXPOSE 3000
-CMD ["node","server.js"]
+
+COPY start.sh ./
+RUN chmod +x start.sh
+
+ENV PORT=3000 \
+    DISPLAY=:99 \
+    VNC_PORT=5900 \
+    NOVNC_PORT=6080
+
+EXPOSE 3000 5900 6080
+
+CMD ["./start.sh"]

--- a/README.md
+++ b/README.md
@@ -24,9 +24,20 @@ Preparado para desplegarse desde **GitHub → Render** con autodeploy.
 ## Desarrollo local con Docker
 ```bash
 docker build -t tipificacion-bot .
-docker run -p 3000:3000 -e SA_JSON="$(cat secrets/sa-key.json)" tipificacion-bot
+docker run -p 3000:3000 -p 5900:5900 -p 6080:6080 \
+  -e SA_JSON="$(cat secrets/sa-key.json)" \
+  -e VNC_PASSWORD="cambia-esta-clave" \
+  tipificacion-bot
 curl http://localhost:3000/
 ```
+
+## Escritorio virtual (VNC/noVNC)
+- **noVNC (recomendado):** abre <http://localhost:6080/vnc.html> y conecta usando `localhost:5900` como host VNC. Si defines la variable `VNC_PASSWORD`, utilízala cuando el visor lo solicite.
+- **Cliente VNC tradicional:** conecta a `localhost:5900` usando la contraseña de `VNC_PASSWORD` (si no la defines, la sesión se expone sin contraseña —no recomendado para entornos públicos).
+- Variables relevantes:
+  - `VNC_PASSWORD`: contraseña para el servidor VNC (`-nopw` por defecto).
+  - `VNC_PORT`: puerto del servidor VNC (por defecto `5900`).
+  - `NOVNC_PORT`: puerto HTTP de noVNC (por defecto `6080`).
 
 ## Despliegue en Render (dos caminos)
 
@@ -42,14 +53,17 @@ curl http://localhost:3000/
 3. Variables de entorno:
    - `PORT=3000`
    - `SA_JSON=<pega aquí el JSON completo>`
+   - Opcional: `VNC_PASSWORD=<contraseña segura>`
 4. Activa **Auto Deploys** en tu branch principal.
 
 ## Probar
 ```bash
-curl -X POST https://<tu-servicio>.onrender.com/run       -H "content-type: application/json"       -d '{"url":"https://example.com","spreadsheetId":"<ID>","range":"Hoja1!A1"}'
+curl -X POST https://<tu-servicio>.onrender.com/run \
+      -H "content-type: application/json" \
+      -d '{"url":"https://example.com","spreadsheetId":"<ID>","range":"Hoja1!A1"}'
 ```
 
 ## Notas
 - Si no defines `SA_JSON` o no pasas `spreadsheetId`, el servicio **no** escribirá en Sheets (solo navegará).
-- Para ver la GUI real del navegador necesitarás un contenedor con noVNC/Guacamole en un VPS. Render funciona perfecto en **headless**.
+- Cambia la contraseña por defecto del servidor VNC antes de exponer el contenedor a Internet.
 - Seguridad: no subas credenciales al repo. Usa variables de entorno / Secret Files.

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export DISPLAY="${DISPLAY:-:99}"
+VNC_PORT="${VNC_PORT:-5900}"
+NOVNC_PORT="${NOVNC_PORT:-6080}"
+XVFB_SCREEN="${XVFB_SCREEN:-1280x720x24}"
+
+# Launch virtual framebuffer
+Xvfb "$DISPLAY" -screen 0 "$XVFB_SCREEN" &
+
+# Give Xvfb a moment to start
+sleep 1
+
+# Start a lightweight window manager
+fluxbox &
+
+# Configure VNC authentication
+if [[ -n "${VNC_PASSWORD:-}" ]]; then
+  VNC_AUTH_OPTS=(-passwd "$VNC_PASSWORD")
+else
+  VNC_AUTH_OPTS=(-nopw)
+fi
+
+# Launch x11vnc bound to the Xvfb display
+x11vnc -display "$DISPLAY" -forever -shared -rfbport "$VNC_PORT" "${VNC_AUTH_OPTS[@]}" -bg
+
+# Start noVNC web client proxy
+/usr/share/novnc/utils/novnc_proxy --vnc "localhost:${VNC_PORT}" --listen "$NOVNC_PORT" &
+
+# Start the Node.js server (foreground)
+exec node server.js


### PR DESCRIPTION
## Summary
- install Fluxbox, x11vnc and noVNC in the Docker image
- add a startup script that launches Xvfb, the desktop stack and the Node service
- document how to reach the virtual desktop over VNC/noVNC and expose the required ports

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb80c4f3dc832cb82dc7d926424a8f